### PR TITLE
Using a default 0 (zero) exit status to indicate success

### DIFF
--- a/src/ConverterCommand.php
+++ b/src/ConverterCommand.php
@@ -76,9 +76,10 @@ class ConverterCommand extends Command
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $converter = new Converter();
+        $exitCode = 0;
 
         foreach (static::$supportedConverters as $converterName => $supportedConverter) {
             if (false !== $input->getOption(strtolower($converterName))) {
@@ -133,8 +134,10 @@ class ConverterCommand extends Command
                             $filename
                         )
                     );
+                    $exitCode = 1;
                 } catch (JsonException $exception) {
                     $output->writeln('<error>Unable to decode given file.</error>');
+                    $exitCode = 1;
                 } catch (StringsException $exception) {
                     throw new UnableToWriteOutputLine(
                         $exception->getMessage()
@@ -162,17 +165,20 @@ class ConverterCommand extends Command
             );
         } catch (NoConvertersEnabledException $exception) {
             $output->writeln('<error>Please include at least 1 converter.</error>');
+            $exitCode = 1;
         } catch (FilesystemException $exception) {
             $output->writeln('<error>Unable to write to output file.</error>');
+            $exitCode = 1;
         } catch (StringsException $exception) {
             throw new UnableToWriteOutputLine(
                 $exception->getMessage()
             );
         } catch (UnableToGetJsonEncodedOutputException $exception) {
             $output->writeln('<error>Unable to get JSON encoded output.</error>');
+            return 1;
         }
 
-        return 1;
+        return $exitCode;
     }
 
     private function option(string $converter): void


### PR DESCRIPTION
Following https://symfony.com/doc/current/console.html#command-lifecycle using a default 0 (zero) exit status to indicate success.

https://www.shellscript.sh/exitcodes.html:

```
Success is traditionally represented with exit 0; failure is normally indicated with a non-zero exit-code. This value can indicate different reasons for failure.
For example, GNU grep returns 0 on success, 1 if no matches were found, and 2 for other errors (syntax errors, non-existent input files, etc).
```
