### PR TITLE
Update converter

### DIFF
--- a/bin/converter
+++ b/bin/converter
@@ -8,6 +8,7 @@ $autoloadFiles = [
     __DIR__.'/../vendor/autoload.php',
     __DIR__.'/../../vendor/autoload.php',
     __DIR__.'/../../../vendor/autoload.php',
+    __DIR__.'/../../../../vendor/autoload.php',
 ];
 
 foreach ($autoloadFiles as $autoloadFile) {


### PR DESCRIPTION
Check one level deeper to find autoload file.

Testing it in an example project failed and exited because it didn't look deep enough to find the autoload.php file.