### PR TITLE
Disable obsolete QA tools and introduce CS fixer in actions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -17,14 +17,10 @@ jobs:
           - 7.3
           - 7.4
         suite:
-          - infection-ci
-          - phan
-          - php-cbf
-          - php-cs
+          - php-cs-fixer
           - phplint
-          - phpstan
           - phpunit
-          - psalm
+          - infection-ci
 
     name: PHP ${{ matrix.php }} testing ${{ matrix.suite }}
     steps:

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -17,7 +17,7 @@ jobs:
           - 7.3
           - 7.4
         suite:
-          - php-cs-fixer
+          - php-cs-fixer-ci
           - phplint
           - phpunit
           - infection-ci

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "psalm": "vendor/bin/psalm src",
         "phplint": "vendor/bin/phplint src",
         "php-cs-fixer": "vendor/bin/php-cs-fixer fix",
+        "php-cs-fixer-ci": "vendor/bin/php-cs-fixer fix --dry-run --stop-on-violation",
         "php-cbf": "vendor/bin/phpcbf src --standard=PSR1,PSR2,PSR12",
         "php-cs": "vendor/bin/phpcs src --standard=PSR1,PSR2,PSR12",
         "phan": "vendor/bin/phan --allow-polyfill-parser src",

--- a/src/Factories/ConverterFactory.php
+++ b/src/Factories/ConverterFactory.php
@@ -39,6 +39,7 @@ class ConverterFactory implements ConverterFactoryInterface
                 );
 
                 break;
+
             case 'PHP_CodeSniffer':
                 $converter = new PhpCodeSnifferConvertToSubset(
                     $validator,
@@ -47,6 +48,7 @@ class ConverterFactory implements ConverterFactoryInterface
                 );
 
                 break;
+
             case 'PHPLint':
                 $converter = new PhpLintConvertToSubset(
                     $validator,
@@ -55,6 +57,7 @@ class ConverterFactory implements ConverterFactoryInterface
                 );
 
                 break;
+
             case 'PHPStan':
                 $converter = new PHPStanConvertToSubset(
                     $validator,
@@ -63,6 +66,7 @@ class ConverterFactory implements ConverterFactoryInterface
                 );
 
                 break;
+
             case 'Psalm':
                 $converter = new PsalmConvertToSubset(
                     $validator,
@@ -71,6 +75,7 @@ class ConverterFactory implements ConverterFactoryInterface
                 );
 
                 break;
+
             case 'PHP-CS-Fixer':
                 $converter = new PHPCSFixerConvertToSubset(
                     $validator,

--- a/src/Factories/ValidatorFactory.php
+++ b/src/Factories/ValidatorFactory.php
@@ -28,22 +28,27 @@ class ValidatorFactory implements ValidatorFactoryInterface
                 $validator = new PhanJsonValidator($json);
 
                 break;
+
             case 'PHP_CodeSniffer':
                 $validator = new PhpCodeSnifferJsonValidator($json);
 
                 break;
+
             case 'PHPLint':
                 $validator = new PhpLintJsonValidator($json);
 
                 break;
+
             case 'PHPStan':
                 $validator = new PHPStanJsonValidator($json);
 
                 break;
+
             case 'Psalm':
                 $validator = new PsalmJsonValidator($json);
 
                 break;
+
             case 'PHP-CS-Fixer':
                 $validator = new PHPCSFixerJsonValidator($json);
 

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -925,8 +925,7 @@ class CommandTest extends TestCase
         string $converter,
         array $output,
         string $name
-    ): void
-    {
+    ): void {
         // Given
         $jsonFileName = __DIR__.'/..'.$jsonInput;
         $jsonInput = file_get_contents(__DIR__.'/..'.$jsonInput);
@@ -968,7 +967,7 @@ class CommandTest extends TestCase
         $commandTester->execute(
             [
                 $converterImplementationOptionName => true,
-                $converterImplementationOptionFilePath => $jsonFileName
+                $converterImplementationOptionFilePath => $jsonFileName,
             ]
         );
 


### PR DESCRIPTION
Disable Phan, Psalm, PHPStan, PHPCS for the time being and add PHP-CS-Fixer to the list of actions that do run.