### PR TITLE
Add severity key in Phan converter

### DIFF
--- a/src/Phan/PhanConvertToSubset.php
+++ b/src/Phan/PhanConvertToSubset.php
@@ -12,9 +12,9 @@ final class PhanConvertToSubset extends AbstractConverter
     private const SEVERITY_LEVELS = [
         0 => 'info',
         5 => 'minor',
-        10 => 'critical'
+        10 => 'critical',
     ];
-    
+
     public function convertToSubset(): void
     {
         try {

--- a/src/Phan/PhanConvertToSubset.php
+++ b/src/Phan/PhanConvertToSubset.php
@@ -9,6 +9,12 @@ use BeechIt\JsonToCodeClimateSubsetConverter\Exceptions\InvalidJsonException;
 
 final class PhanConvertToSubset extends AbstractConverter
 {
+    private const SEVERITY_LEVELS = [
+        0 => 'info',
+        5 => 'minor',
+        10 => 'critical'
+    ];
+    
     public function convertToSubset(): void
     {
         try {
@@ -22,6 +28,7 @@ final class PhanConvertToSubset extends AbstractConverter
                         $node->location->path,
                         $node->location->lines->begin
                     ),
+                    'severity' => self::SEVERITY_LEVELS[$node->severity] ?? null,
                     'location' => [
                         'path' => $node->location->path,
                         'lines' => [

--- a/tests/Phan/PhanConverterTest.php
+++ b/tests/Phan/PhanConverterTest.php
@@ -40,6 +40,7 @@ class PhanConverterTest extends TestCase
                 [
                     'description' => '(Phan) UndefError PhanUndeclaredClassConstant Reference to constant class from undeclared class \PhpParser\Node\Stmt\ClassMethod',
                     'fingerprint' => 'e8547906ee21b4f8e8804de980a9d239',
+                    'severity' => 'critical',
                     'location' => [
                         'path' => 'app/Class.php',
                         'lines' => [

--- a/tests/Phan/fixtures/output.json
+++ b/tests/Phan/fixtures/output.json
@@ -2,6 +2,7 @@
     {
         "description": "(Phan) UndefError PhanUndeclaredClassConstant Reference to constant class from undeclared class \\PhpParser\\Node\\Stmt\\ClassMethod",
         "fingerprint": "e8547906ee21b4f8e8804de980a9d239",
+        "severity": "critical",
         "location": {
             "path": "app/Class.php",
             "lines": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,6 +34,7 @@ class TestCase extends BaseTestCase
                 'output' => [
                     'description' => '(Phan) UndefError PhanUndeclaredClassConstant Reference to constant class from undeclared class \PhpParser\Node\Stmt\ClassMethod',
                     'fingerprint' => 'e8547906ee21b4f8e8804de980a9d239',
+                    'severity' => 'critical',
                     'location' => [
                         'path' => 'app/Class.php',
                         'lines' => [

--- a/tests/fixtures/output.json
+++ b/tests/fixtures/output.json
@@ -2,6 +2,7 @@
     {
         "description": "(Phan) UndefError PhanUndeclaredClassConstant Reference to constant class from undeclared class \\PhpParser\\Node\\Stmt\\ClassMethod",
         "fingerprint": "e8547906ee21b4f8e8804de980a9d239",
+        "severity": "critical",
         "location": {
             "path": "app/Class.php",
             "lines": {


### PR DESCRIPTION
Reported errors by Phan are not recognized by Gitlab Code Quality due to missing severity key in the generated Code Climate nodes.

See https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool for a list of the required elements